### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,67 +6,67 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AllAboutEE      KEYWORD1
-IRsend          KEYWORD1
+AllAboutEE	KEYWORD1
+IRsend	KEYWORD1
 IRControlButton KEYWORD1
-ButtonID        KEYWORD1
-IRControl       KEYWORD1
-IRrecv          KEYWORD1
+ButtonID	KEYWORD1
+IRControl	KEYWORD1
+IRrecv	KEYWORD1
 decoder_results KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setButtonCode           KEYWORD2
-setButtonRawCode        KEYWORD2
-sendSignal              KEYWORD2
-begin                   KEYWORD2
-setFlagValue            KEYWORD2
-getFlagValue            KEYWORD2
-interrupt               KEYWORD2
+setButtonCode	KEYWORD2
+setButtonRawCode	KEYWORD2
+sendSignal	KEYWORD2
+begin	KEYWORD2
+setFlagValue	KEYWORD2
+getFlagValue	KEYWORD2
+interrupt	KEYWORD2
 
-sendNEC                 KEYWORD2
-sendSony                KEYWORD2
-sendRaw                 KEYWORD2
-sendRC5                 KEYWORD2
-sendRC6                 KEYWORD2
-sendDISH                KEYWORD2
-sendSharp               KEYWORD2
-sendSharpRaw            KEYWORD2
-sendPanasonic           KEYWORD2
-sendJVC                 KEYWORD2
-sendSAMSUNG             KEYWORD2
-enableIROut             KEYWORD2
-mark                    KEYWORD2
-space                   KEYWORD2
+sendNEC	KEYWORD2
+sendSony	KEYWORD2
+sendRaw	KEYWORD2
+sendRC5	KEYWORD2
+sendRC6	KEYWORD2
+sendDISH	KEYWORD2
+sendSharp	KEYWORD2
+sendSharpRaw	KEYWORD2
+sendPanasonic	KEYWORD2
+sendJVC	KEYWORD2
+sendSAMSUNG	KEYWORD2
+enableIROut	KEYWORD2
+mark	KEYWORD2
+space	KEYWORD2
 
-setId                   KEYWORD2
-getId                   KEYWORD2
-getHexCode              KEYWORD2
-setHexCode              KEYWORD2
-setCodeLength           KEYWORD2
-getCodeLength           KEYWORD2
-getRawCode              KEYWORD2
-setRawCode              KEYWORD2
-setProtocol             KEYWORD2
-getProtocol             KEYWORD2
+setId	KEYWORD2
+getId	KEYWORD2
+getHexCode	KEYWORD2
+setHexCode	KEYWORD2
+setCodeLength	KEYWORD2
+getCodeLength	KEYWORD2
+getRawCode	KEYWORD2
+setRawCode	KEYWORD2
+setProtocol	KEYWORD2
+getProtocol	KEYWORD2
 
-blink13                 KEYWORD2
-decode                  KEYWORD2
-enableIRIn              KEYWORD2
-resume                  KEYWORD2
+blink13	KEYWORD2
+decode	KEYWORD2
+enableIRIn	KEYWORD2
+resume	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-NEC             LITERAL1
-SONY            LITERAL1
-RC5             LITERAL1
-RC6             LITERAL1
-DISH            LITERAL1
-SENDSHARPRAW    LITERAL1
-SAMSUNG         LITERAL1
-RAW             LITERAL1
-FLAG_READGPIO   LITERAL1
+NEC	LITERAL1
+SONY	LITERAL1
+RC5	LITERAL1
+RC6	LITERAL1
+DISH	LITERAL1
+SENDSHARPRAW	LITERAL1
+SAMSUNG	LITERAL1
+RAW	LITERAL1
+FLAG_READGPIO	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords